### PR TITLE
modify path for tests that shell out on windows

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -160,8 +160,11 @@ end
 @test CartesianTest.f(1,2,3,4) == (1,2,3,4)
 @test CartesianTest.f(1,2,3,4,5) == (1,2,3,4,5)
 
-@test readall(pipeline(`echo hello`, `sort`)) == "hello\n"
-@test success(pipeline(`true`, `true`))
+extrapath = @windows? joinpath(JULIA_HOME,"..","Git","usr","bin")*";" : ""
+withenv("PATH" => extrapath * ENV["PATH"]) do
+    @test readall(pipeline(`echo hello`, `sort`)) == "hello\n"
+    @test success(pipeline(`true`, `true`))
+end
 
 let convert_funcs_and_types =
     ((integer, :Integer), (signed, :Signed), (unsigned, :Unsigned),


### PR DESCRIPTION
without this, 0.5 nightlies (though new nightlies haven't been built for about a week, so not yet)
and 0.4.2 will call the windows native versions of these rather than coreutils,
giving either different line endings or more substantially different behaviorCompat.jl